### PR TITLE
chore: update toolchain file to fix zed extension build

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,5 @@
 [toolchain]
-channel = "nightly-2025-04-20"
+channel = "nightly-2025-04-20" 
+
+components = ["rust-src"]
+targets = ["wasm32-wasip2"]


### PR DESCRIPTION
Fixes zed extension build issues. right now the zed extension is pointed to my fork. once this is merged it can be pointed back here.

https://github.com/zed-industries/extensions/pull/3734